### PR TITLE
Fix alliance admin visibility

### DIFF
--- a/cogs/alliance_member_operations.py
+++ b/cogs/alliance_member_operations.py
@@ -1379,57 +1379,39 @@ class AllianceMemberOperations(commands.Cog):
                 is_initial = admin_result[0]
                 
             if is_initial == 1:
-                
+
                 with sqlite3.connect('db/alliance.sqlite') as alliance_db:
                     cursor = alliance_db.cursor()
                     cursor.execute("SELECT alliance_id, name FROM alliance_list ORDER BY name")
                     alliances = cursor.fetchall()
                     return alliances, [], True
-            
-            
-            server_alliances = []
-            special_alliances = []
-            
-            
-            with sqlite3.connect('db/alliance.sqlite') as alliance_db:
-                cursor = alliance_db.cursor()
-                cursor.execute("""
-                    SELECT DISTINCT alliance_id, name 
-                    FROM alliance_list 
-                    WHERE discord_server_id = ?
-                    ORDER BY name
-                """, (guild_id,))
-                server_alliances = cursor.fetchall()
-            
-            
+
+
             with sqlite3.connect('db/settings.sqlite') as settings_db:
                 cursor = settings_db.cursor()
                 cursor.execute("""
-                    SELECT alliances_id 
-                    FROM adminserver 
+                    SELECT alliances_id
+                    FROM adminserver
                     WHERE admin = ?
                 """, (user_id,))
-                special_alliance_ids = cursor.fetchall()
-                
-            
-            if special_alliance_ids:
-                with sqlite3.connect('db/alliance.sqlite') as alliance_db:
-                    cursor = alliance_db.cursor()
-                    placeholders = ','.join('?' * len(special_alliance_ids))
-                    cursor.execute(f"""
-                        SELECT DISTINCT alliance_id, name
-                        FROM alliance_list
-                        WHERE alliance_id IN ({placeholders})
-                        ORDER BY name
-                    """, [aid[0] for aid in special_alliance_ids])
-                    special_alliances = cursor.fetchall()
-            
-            all_alliances = list({(aid, name) for aid, name in (server_alliances + special_alliances)})
-            
-            if not all_alliances and not special_alliances:
+                special_alliance_ids = [aid[0] for aid in cursor.fetchall()]
+
+            if not special_alliance_ids:
                 return [], [], False
-            
-            return all_alliances, special_alliances, False
+
+            with sqlite3.connect('db/alliance.sqlite') as alliance_db:
+                cursor = alliance_db.cursor()
+                placeholders = ','.join('?' * len(special_alliance_ids))
+                cursor.execute(f"""
+                    SELECT DISTINCT alliance_id, name
+                    FROM alliance_list
+                    WHERE alliance_id IN ({placeholders})
+                    ORDER BY name
+                """, special_alliance_ids)
+                alliances = cursor.fetchall()
+                special_alliances = alliances
+
+            return alliances, special_alliances, False
                 
         except Exception as e:
             return [], [], False

--- a/cogs/changes.py
+++ b/cogs/changes.py
@@ -101,47 +101,35 @@ class Changes(commands.Cog):
                     cursor.execute("SELECT alliance_id, name FROM alliance_list ORDER BY name")
                     alliances = cursor.fetchall()
                     return alliances, [], True
-            
-            server_alliances = []
-            special_alliances = []
-            
-            with sqlite3.connect('db/alliance.sqlite') as alliance_db:
-                cursor = alliance_db.cursor()
-                cursor.execute("""
-                    SELECT DISTINCT alliance_id, name 
-                    FROM alliance_list 
-                    WHERE discord_server_id = ?
-                    ORDER BY name
-                """, (guild_id,))
-                server_alliances = cursor.fetchall()
-            
+
             with sqlite3.connect('db/settings.sqlite') as settings_db:
                 cursor = settings_db.cursor()
                 cursor.execute("""
-                    SELECT alliances_id 
-                    FROM adminserver 
+                    SELECT alliances_id
+                    FROM adminserver
                     WHERE admin = ?
                 """, (user_id,))
-                special_alliance_ids = cursor.fetchall()
-                
-            if special_alliance_ids:
-                with sqlite3.connect('db/alliance.sqlite') as alliance_db:
-                    cursor = alliance_db.cursor()
-                    placeholders = ','.join('?' * len(special_alliance_ids))
-                    cursor.execute(f"""
-                        SELECT DISTINCT alliance_id, name
-                        FROM alliance_list
-                        WHERE alliance_id IN ({placeholders})
-                        ORDER BY name
-                    """, [aid[0] for aid in special_alliance_ids])
-                    special_alliances = cursor.fetchall()
-            
-            all_alliances = list({(aid, name) for aid, name in (server_alliances + special_alliances)})
-            
-            if not all_alliances and not special_alliances:
+                special_alliance_ids = [aid[0] for aid in cursor.fetchall()]
+
+            if not special_alliance_ids:
                 return [], [], False
-            
-            return all_alliances, special_alliances, False
+
+            with sqlite3.connect('db/alliance.sqlite') as alliance_db:
+                cursor = alliance_db.cursor()
+                placeholders = ','.join('?' * len(special_alliance_ids))
+                cursor.execute(f"""
+                    SELECT DISTINCT alliance_id, name
+                    FROM alliance_list
+                    WHERE alliance_id IN ({placeholders})
+                    ORDER BY name
+                """, special_alliance_ids)
+                alliances = cursor.fetchall()
+                special_alliances = alliances
+
+            if not alliances:
+                return [], [], False
+
+            return alliances, special_alliances, False
                 
         except Exception as e:
             print(f"Error in get_admin_alliances: {e}")

--- a/cogs/gift_operations.py
+++ b/cogs/gift_operations.py
@@ -1486,30 +1486,21 @@ class GiftOperations(commands.Cog):
             return self.alliance_cursor.fetchall()
 
         if guild_id:
-            self.alliance_cursor.execute("""
-                SELECT DISTINCT alliance_id, name 
-                FROM alliance_list 
-                WHERE discord_server_id = ?
-            """, (guild_id,))
-            guild_alliances = self.alliance_cursor.fetchall()
-
-            self.settings_cursor.execute("""
-                SELECT alliances_id FROM adminserver WHERE admin = ?
-            """, (user_id,))
+            self.settings_cursor.execute(
+                "SELECT alliances_id FROM adminserver WHERE admin = ?",
+                (user_id,)
+            )
             special_alliance_ids = [row[0] for row in self.settings_cursor.fetchall()]
 
-            if special_alliance_ids:
-                placeholders = ','.join('?' * len(special_alliance_ids))
-                self.alliance_cursor.execute(f"""
-                    SELECT alliance_id, name FROM alliance_list 
-                    WHERE alliance_id IN ({placeholders})
-                """, special_alliance_ids)
-                special_alliances = self.alliance_cursor.fetchall()
-            else:
-                special_alliances = []
+            if not special_alliance_ids:
+                return []
 
-            all_alliances = list(set(guild_alliances + special_alliances))
-            return all_alliances
+            placeholders = ','.join('?' * len(special_alliance_ids))
+            self.alliance_cursor.execute(
+                f"SELECT alliance_id, name FROM alliance_list WHERE alliance_id IN ({placeholders})",
+                special_alliance_ids,
+            )
+            return self.alliance_cursor.fetchall()
 
         return []
 


### PR DESCRIPTION
## Summary
- limit alliance admins to only assigned alliances across the bot
- remove fallback to server alliances when no assignments exist

## Testing
- `python -m py_compile cogs/alliance.py cogs/alliance_member_operations.py cogs/changes.py cogs/gift_operations.py main.py`


