### PR TITLE
Fix DM usage for /settings

### DIFF
--- a/cogs/alliance.py
+++ b/cogs/alliance.py
@@ -113,16 +113,22 @@ class Alliance(commands.Cog):
 
     @app_commands.command(name="settings", description="Open settings menu.")
     async def settings(self, interaction: discord.Interaction):
+        if interaction.guild is None:
+            await interaction.response.send_message(
+                "❌ This command must be used in a server, not in DMs.",
+                ephemeral=True,
+            )
+            return
+
         try:
-            if interaction.guild is not None: # Check bot permissions only if in a guild
-                perm_check = interaction.guild.get_member(interaction.client.user.id)
-                if not perm_check.guild_permissions.administrator:
-                    await interaction.response.send_message(
-                        "Beeb boop 🤖 I need **Administrator** permissions to function. "
-                        "Go to server settings --> Roles --> find my role --> scroll down and turn on Administrator", 
-                        ephemeral=True
-                    )
-                    return
+            perm_check = interaction.guild.get_member(interaction.client.user.id)
+            if not perm_check or not perm_check.guild_permissions.administrator:
+                await interaction.response.send_message(
+                    "Beeb boop 🤖 I need **Administrator** permissions to function. "
+                    "Go to server settings --> Roles --> find my role --> scroll down and turn on Administrator",
+                    ephemeral=True
+                )
+                return
                 
             self.c_settings.execute("SELECT COUNT(*) FROM admin")
             admin_count = self.c_settings.fetchone()[0]


### PR DESCRIPTION
## Summary
- handle missing guild when running the settings command
- alert users that it must be run in a server

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v 'docker/docker-compose.py')`


------
https://chatgpt.com/codex/tasks/task_e_6845804925e4832f84818fae44acf04c