### PR TITLE
Fix DM usage for /settings

### DIFF
--- a/cogs/alliance.py
+++ b/cogs/alliance.py
@@ -114,13 +114,19 @@ class Alliance(commands.Cog):
     @app_commands.command(name="settings", description="Open settings menu.")
     async def settings(self, interaction: discord.Interaction):
         try:
-            if interaction.guild is not None: # Check bot permissions only if in a guild
+            ephemeral = interaction.guild is not None
+            if interaction.guild is None:
+                await interaction.response.send_message(
+                    "❌ This command must be used in a server, not in DMs."
+                )
+                return
+            if interaction.guild is not None:  # Check bot permissions only if in a guild
                 perm_check = interaction.guild.get_member(interaction.client.user.id)
-                if not perm_check.guild_permissions.administrator:
+                if not perm_check or not perm_check.guild_permissions.administrator:
                     await interaction.response.send_message(
                         "Beeb boop 🤖 I need **Administrator** permissions to function. "
-                        "Go to server settings --> Roles --> find my role --> scroll down and turn on Administrator", 
-                        ephemeral=True
+                        "Go to server settings --> Roles --> find my role --> scroll down and turn on Administrator",
+                        ephemeral=ephemeral
                     )
                     return
                 
@@ -145,7 +151,7 @@ class Alliance(commands.Cog):
                     ),
                     color=discord.Color.green()
                 )
-                await interaction.response.send_message(embed=first_use_embed, ephemeral=True)
+                await interaction.response.send_message(embed=first_use_embed, ephemeral=ephemeral)
                 
                 await asyncio.sleep(3)
                 
@@ -154,8 +160,8 @@ class Alliance(commands.Cog):
 
             if admin is None:
                 await interaction.response.send_message(
-                    "You do not have permission to access this menu.", 
-                    ephemeral=True
+                    "You do not have permission to access this menu.",
+                    ephemeral=ephemeral
                 )
                 return
 
@@ -236,27 +242,28 @@ class Alliance(commands.Cog):
             if admin_count == 0:
                 await interaction.edit_original_response(embed=embed, view=view)
             else:
-                await interaction.response.send_message(embed=embed, view=view)
+                await interaction.response.send_message(embed=embed, view=view, ephemeral=ephemeral)
 
         except Exception as e:
             if not any(error_code in str(e) for error_code in ["10062", "40060"]):
                 print(f"Settings command error: {e}")
             error_message = "An error occurred while processing your request."
             if not interaction.response.is_done():
-                await interaction.response.send_message(error_message, ephemeral=True)
+                await interaction.response.send_message(error_message, ephemeral=ephemeral)
             else:
-                await interaction.followup.send(error_message, ephemeral=True)
+                await interaction.followup.send(error_message, ephemeral=ephemeral)
 
     @commands.Cog.listener()
     async def on_interaction(self, interaction: discord.Interaction):
         if interaction.type == discord.InteractionType.component:
+            ephemeral = interaction.guild is not None
             custom_id = interaction.data.get("custom_id")
             user_id = interaction.user.id
             self.c_settings.execute("SELECT id, is_initial FROM admin WHERE id = ?", (user_id,))
             admin = self.c_settings.fetchone()
 
             if admin is None:
-                await interaction.response.send_message("You do not have permission to perform this action.", ephemeral=True)
+                await interaction.response.send_message("You do not have permission to perform this action.", ephemeral=ephemeral)
                 return
 
             try:


### PR DESCRIPTION
## Summary
- gracefully handle direct messages for the settings command
- avoid ephemeral messages outside of guilds

## Testing
- `python -m py_compile $(cat /tmp/python_files.txt)`

------
https://chatgpt.com/codex/tasks/task_e_6845804925e4832f84818fae44acf04c