### PR TITLE
Add DM context check for Bear Trap

### DIFF
--- a/cogs/bear_trap.py
+++ b/cogs/bear_trap.py
@@ -654,6 +654,14 @@ class BearTrap(commands.Cog):
         return times
 
     async def show_bear_trap_menu(self, interaction: discord.Interaction):
+        if interaction.guild is None:
+            message = "❌ This command can only be used in a server channel."
+            try:
+                await interaction.response.send_message(message)
+            except discord.InteractionResponded:
+                await interaction.followup.send(message)
+            return
+
         try:
             times = self.get_world_times()
             time_display = "\n".join([


### PR DESCRIPTION
## Summary
- guard against running the Bear Trap menu in DMs

## Testing
- `python3 -m py_compile cogs/bear_trap.py`
- `python3 -m py_compile cogs/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6848292d36b8832fba41aad0dbd5bade