### PR TITLE
Add event preset schema

### DIFF
--- a/event_presets.py
+++ b/event_presets.py
@@ -1,0 +1,156 @@
+# Event preset configurations for Whiteout Survival events
+
+EVENT_PRESETS = {
+    "bear_trap": {
+        "event_name": "bear_trap",
+        "default_title": "🐻 Bear Trap Alert!",
+        "default_description": "Bear Hunt starting soon! Prepare your heroes and join rallies for maximum damage!",
+        "default_color": "#8B4513",
+        "default_thumbnail": "bear_trap_icon.png",
+        "default_reminder_times": [60, 30, 10, 5],
+        "typical_duration": 30,
+        "frequency_type": "every_2_days",
+        "urgency_level": 5,
+        "quick_tips": [
+            "Use proper rally heroes for joining",
+            "Coordinate with alliance for maximum damage",
+            "Check hero formations before event starts"
+        ]
+    },
+    "svs": {
+        "event_name": "svs",
+        "default_title": "⚔️ State vs State - Prepare for War!",
+        "default_description": "SVS event starting! Time to show our state's dominance!",
+        "default_color": "#DC143C",
+        "default_thumbnail": "svs_icon.png",
+        "default_reminder_times": [1440, 360, 60, 30],
+        "typical_duration": 4320,
+        "frequency_type": "weekly",
+        "urgency_level": 5,
+        "quick_tips": [
+            "Ensure furnace levels are compatible",
+            "Stock up on healing items",
+            "Coordinate with alliance for group attacks"
+        ]
+    },
+    "fortress": {
+        "event_name": "fortress",
+        "default_title": "🏰 Fortress Battle Incoming",
+        "default_description": "Prepare for the weekly fortress battle!",
+        "default_color": "#1E90FF",
+        "default_thumbnail": "fortress_icon.png",
+        "default_reminder_times": [1440, 120],
+        "typical_duration": 60,
+        "frequency_type": "weekly",
+        "urgency_level": 4,
+        "quick_tips": []
+    },
+    "alliance_mob": {
+        "event_name": "alliance_mob",
+        "default_title": "🤝 Alliance Mobilization",
+        "default_description": "Alliance Mobilization begins soon!",
+        "default_color": "#32CD32",
+        "default_thumbnail": "alliance_mob_icon.png",
+        "default_reminder_times": [1440],
+        "typical_duration": 8640,
+        "frequency_type": "biweekly",
+        "urgency_level": 3,
+        "quick_tips": []
+    },
+    "alliance_champ": {
+        "event_name": "alliance_champ",
+        "default_title": "🏆 Alliance Championship",
+        "default_description": "Alliance Championship is starting!",
+        "default_color": "#FFD700",
+        "default_thumbnail": "alliance_champ_icon.png",
+        "default_reminder_times": [1440],
+        "typical_duration": 2880,
+        "frequency_type": "monthly",
+        "urgency_level": 3,
+        "quick_tips": []
+    },
+    "alliance_showdown": {
+        "event_name": "alliance_showdown",
+        "default_title": "⚡ Alliance Showdown",
+        "default_description": "Get ready for Alliance Showdown!",
+        "default_color": "#FF8C00",
+        "default_thumbnail": "alliance_showdown_icon.png",
+        "default_reminder_times": [1440],
+        "typical_duration": 60,
+        "frequency_type": "monthly",
+        "urgency_level": 3,
+        "quick_tips": []
+    },
+    "castle_battle": {
+        "event_name": "castle_battle",
+        "default_title": "🏛️ Castle Battle",
+        "default_description": "Castle Battle begins soon!",
+        "default_color": "#8A2BE2",
+        "default_thumbnail": "castle_battle_icon.png",
+        "default_reminder_times": [60, 10],
+        "typical_duration": 30,
+        "frequency_type": "weekly",
+        "urgency_level": 4,
+        "quick_tips": []
+    },
+    "crazy_joe": {
+        "event_name": "crazy_joe",
+        "default_title": "🎪 Crazy Joe Alert",
+        "default_description": "Crazy Joe event is about to start!",
+        "default_color": "#FF1493",
+        "default_thumbnail": "crazy_joe_icon.png",
+        "default_reminder_times": [60, 30],
+        "typical_duration": 30,
+        "frequency_type": "weekly",
+        "urgency_level": 4,
+        "quick_tips": []
+    },
+    "foundry": {
+        "event_name": "foundry",
+        "default_title": "🔥 Foundry Battle",
+        "default_description": "Foundry Battle is near!",
+        "default_color": "#FF4500",
+        "default_thumbnail": "foundry_icon.png",
+        "default_reminder_times": [60],
+        "typical_duration": 30,
+        "frequency_type": "monthly",
+        "urgency_level": 3,
+        "quick_tips": []
+    },
+    "treasure": {
+        "event_name": "treasure",
+        "default_title": "💎 Treasure Hunter",
+        "default_description": "Treasure Hunter event approaching!",
+        "default_color": "#20B2AA",
+        "default_thumbnail": "treasure_icon.png",
+        "default_reminder_times": [60],
+        "typical_duration": 1440,
+        "frequency_type": "monthly",
+        "urgency_level": 2,
+        "quick_tips": []
+    },
+    "fishing": {
+        "event_name": "fishing",
+        "default_title": "🎣 Fishing Tournament",
+        "default_description": "Grab your rods! Fishing Tournament soon!",
+        "default_color": "#00BFFF",
+        "default_thumbnail": "fishing_icon.png",
+        "default_reminder_times": [60],
+        "typical_duration": 1440,
+        "frequency_type": "monthly",
+        "urgency_level": 2,
+        "quick_tips": []
+    },
+    "tundra": {
+        "event_name": "tundra",
+        "default_title": "🗺️ Tundra Adventure",
+        "default_description": "Embark on a Tundra Adventure soon!",
+        "default_color": "#87CEEB",
+        "default_thumbnail": "tundra_icon.png",
+        "default_reminder_times": [60],
+        "typical_duration": 2880,
+        "frequency_type": "monthly",
+        "urgency_level": 2,
+        "quick_tips": []
+    }
+}


### PR DESCRIPTION
# Summary
- add `event_presets.py` containing presets for common Whiteout Survival events
- update `bear_trap.py` database schema to include event specific columns
- load event presets on startup and expose helper to fetch them

