### PR TITLE
Add basic Flask dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ After switching to ONNX based [ddddocr](https://github.com/sml2h3/ddddocr), syst
 ### ⚠️ **IMPORTANT ⚠️**
  - **Are you installing for the first time?** Follow the instructions [for New Installations](https://github.com/whiteout-project/bot?tab=readme-ov-file#for-new-installations) instead.
  - If you run your bot on Windows, there is a known issue with onnxruntime + an outdated Visual C++ library. To overcome this, install [the latest version of Visual C++](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170) and then run `main.py` again.
- - If you run your bot non-interactively, for example in a container or as a systemd service, you should run `main.py --autoupdate` to prevent the bot from using the interactive update prompt.
- - The current version of the bot will create a backup of your database folder to `db.bak` automatically during updates, so you do not need to worry about it anymore.
+- If you run your bot non-interactively, for example in a container or as a systemd service, you should run `main.py --autoupdate` to prevent the bot from using the interactive update prompt.
+- To view alliance and gift code statistics in a browser, start the bot with `main.py --dashboard` and open `http://localhost:5000`.
+- The current version of the bot will create a backup of your database folder to `db.bak` automatically during updates, so you do not need to worry about it anymore.
 
 ### ⚠️ Python 3.13 Users: Read This or Else!
 - **`ddddocr` still doesn’t support Python 3.13+.**  

--- a/dashboard/__init__.py
+++ b/dashboard/__init__.py
@@ -1,0 +1,3 @@
+from .app import create_app
+
+__all__ = ["create_app"]

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1,6 +1,8 @@
 import sqlite3
 from flask import Flask, jsonify
 
+HOME_ROUTES = ["/alliances", "/giftcodes/stats", "/notifications"]
+
 ALLIANCE_DB_PATH = "db/alliance.sqlite"
 GIFT_DB_PATH = "db/giftcode.sqlite"
 NOTIFICATION_DB_PATH = "db/beartime.sqlite"
@@ -14,6 +16,11 @@ def _get_connection(path: str) -> sqlite3.Connection:
 
 def create_app() -> Flask:
     app = Flask(__name__)
+
+    @app.route("/")
+    def index():
+        """Simple JSON message listing available routes."""
+        return jsonify({"message": "Dashboard is running", "routes": HOME_ROUTES})
 
     @app.route("/alliances")
     def list_alliances():

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1,0 +1,44 @@
+import sqlite3
+from flask import Flask, jsonify
+
+ALLIANCE_DB_PATH = "db/alliance.sqlite"
+GIFT_DB_PATH = "db/giftcode.sqlite"
+NOTIFICATION_DB_PATH = "db/beartime.sqlite"
+
+
+def _get_connection(path: str) -> sqlite3.Connection:
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def create_app() -> Flask:
+    app = Flask(__name__)
+
+    @app.route("/alliances")
+    def list_alliances():
+        with _get_connection(ALLIANCE_DB_PATH) as conn:
+            rows = conn.execute("SELECT * FROM alliance_list").fetchall()
+            return jsonify([dict(row) for row in rows])
+
+    @app.route("/giftcodes/stats")
+    def giftcode_stats():
+        with _get_connection(GIFT_DB_PATH) as conn:
+            total_codes = conn.execute("SELECT COUNT(*) FROM gift_codes").fetchone()[0]
+            total_claims = conn.execute("SELECT COUNT(*) FROM user_giftcodes").fetchone()[0]
+            unique_users = conn.execute("SELECT COUNT(DISTINCT fid) FROM user_giftcodes").fetchone()[0]
+        return jsonify({
+            "total_codes": total_codes,
+            "total_claims": total_claims,
+            "unique_users": unique_users,
+        })
+
+    @app.route("/notifications")
+    def notifications():
+        with _get_connection(NOTIFICATION_DB_PATH) as conn:
+            rows = conn.execute(
+                "SELECT id, guild_id, channel_id, hour, minute, timezone, description, next_notification FROM bear_notifications"
+            ).fetchall()
+            return jsonify([dict(row) for row in rows])
+
+    return app

--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ PIP_INSTALL_TIMEOUT = 1200
 DOWNLOAD_TIMEOUT = 300
 OCR_INSTALL_TIMEOUT = 600
 DASHBOARD_PORT = 5000
+DASHBOARD_DEPENDENCIES = ["flask"]
 
 def is_container() -> bool:
     return os.path.exists("/.dockerenv") or os.path.exists("/var/run/secrets/kubernetes.io")
@@ -333,6 +334,33 @@ def check_ocr_dependencies():
             print("Please install latest 64-bit from: https://aka.ms/vs/17/release/vc_redist.x64.exe")
         return False
 
+def check_dashboard_dependencies() -> bool:
+    """Install Flask if the dashboard flag is used and it's missing."""
+    if "--dashboard" not in sys.argv:
+        return True
+
+    missing = []
+    for package in DASHBOARD_DEPENDENCIES:
+        if importlib.util.find_spec(package) is None:
+            print(f"✗ {package} - MISSING")
+            missing.append(package)
+
+    if missing:
+        print(f"Installing {len(missing)} dashboard packages...")
+        for package in missing:
+            try:
+                subprocess.check_call(
+                    [sys.executable, "-m", "pip", "install", package, "--no-cache-dir"],
+                    timeout=PIP_INSTALL_TIMEOUT,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+                print(f"✓ {package} installed successfully")
+            except Exception as e:
+                print(f"✗ Failed to install {package}: {e}")
+                return False
+    return True
+
 def setup_dependencies():
     """Main function to set up all dependencies."""
     print("Starting dependency check...")
@@ -351,7 +379,10 @@ def setup_dependencies():
     ocr_success = check_ocr_dependencies()
     if not ocr_success:
         print("OCR setup failed, but continuing with basic functionality")
-    
+
+    if not check_dashboard_dependencies():
+        return False
+
     print("Dependency check completed...")
     return True
 


### PR DESCRIPTION
## Summary
- add simple Flask-based dashboard module
- show alliance data, gift code stats, and notification schedules via dashboard routes
- allow starting the dashboard with `--dashboard` option
