### PR TITLE
Fix safe_remove compatibility on older Python versions

### DIFF
--- a/main.py
+++ b/main.py
@@ -135,7 +135,11 @@ def safe_remove(path, is_dir=None):
     try:
         if is_dir:
             if sys.platform == "win32":
-                shutil.rmtree(path, onexc=remove_readonly)
+                # Python 3.12+ supports onexc, older versions use onerror
+                if sys.version_info >= (3, 12):
+                    shutil.rmtree(path, onexc=remove_readonly)
+                else:
+                    shutil.rmtree(path, onerror=remove_readonly)
             else:
                 shutil.rmtree(path)
         else:


### PR DESCRIPTION
## Summary
- update Windows removal helper to support Python versions before 3.12 by falling back to `onerror`
- keep read-only clearing behavior for directory removal

